### PR TITLE
Fix Next.js build failures caused by remote font downloads

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,6 +17,8 @@
     --input: 0 0% 100%;
     --ring: 152 72% 40%;
     --radius: 0.5rem;
+    --font-sans: 'Inter', 'Helvetica Neue', Helvetica, Arial, system-ui, sans-serif;
+    --font-script: 'Dancing Script', 'Brush Script MT', 'Comic Sans MS', cursive;
   }
 }
 
@@ -26,16 +28,16 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-sans), 'Inter', system-ui, sans-serif;
+    font-family: var(--font-sans);
   }
 }
 
 .font-sans {
-  font-family: var(--font-sans), 'Inter', system-ui, sans-serif;
+  font-family: var(--font-sans);
 }
 
 .font-script {
-  font-family: var(--font-script), 'Dancing Script', cursive;
+  font-family: var(--font-script);
 }
 
 /* Smooth scrolling */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,10 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import Script from 'next/script';
-import { Inter, Dancing_Script } from 'next/font/google';
 import { SiteHeader } from '@/components/site-header';
 import { SiteFooter } from '@/components/site-footer';
 import { Preloader } from '@/components/preloader';
 import { getLocalBusinessSchema, getNavigation, getSettings } from '@/lib/content';
-
-const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
-const dancing = Dancing_Script({ subsets: ['latin'], weight: ['400', '500', '600', '700'], variable: '--font-script' });
 
 const settings = getSettings();
 const navigation = getNavigation();
@@ -44,7 +40,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="fr" className={`${inter.variable} ${dancing.variable}`}>
+    <html lang="fr">
       <body className="min-h-screen bg-emerald-50 text-slate-900 font-sans">
         <Preloader />
         <SiteHeader navigation={navigation} />

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -3,7 +3,17 @@
 // Inspired by react-hot-toast library
 import * as React from 'react';
 
-import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
+type ToastActionElement = React.ReactElement | null;
+
+interface ToastProps {
+  id?: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: ToastActionElement;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  duration?: number;
+}
 
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;


### PR DESCRIPTION
## Summary
- remove the `next/font/google` imports in the root layout and rely on CSS variables for font fallbacks so the build no longer needs to download Google Fonts
- define the toast prop types locally inside `use-toast` to satisfy the Next.js type checking step

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e12674f3a08329aae156f2b6402ef6